### PR TITLE
`files.upload` : 内部で`files_upload_v2`を使うようにしました。

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   open-pull-requests-limit: 10

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ venv.bak/
 tests/out/
 
 pip-wheel-metadata/
+
+out/

--- a/slack_primitive_cli/command/files.py
+++ b/slack_primitive_cli/command/files.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 @click.command(name="files.upload", help="Uploads or creates a file. See https://api.slack.com/methods/files.upload ")
 @click.option("--token", envvar=TOKEN_ENVVAR, required=True, help=TOKEN_HELP_MESSAGE)
-@click.option("--channels", required=True, help="Comma-separated list of channel names or IDs where the file will be shared.")
+@click.option("--channel_id", required=True, help="Channel IDs where the file will be shared.")
 @optgroup.group("File contents", cls=RequiredMutuallyExclusiveOptionGroup)
 @optgroup.option("--file", help="File contents via multipart/form-data. If omitting this parameter, you must submit content.")
 @optgroup.option("--content", help="File contents via a POST variable. If omitting this parameter, you must provide a file.")
@@ -29,8 +29,8 @@ def upload(token, channels, file, content, filename, filetype, initial_comment, 
     if filename is None and file is not None:
         filename = os.path.basename(file)
 
-    response = client.files_upload(
-        channels=channels,
+    response = client.files_upload_v2(
+        channel=channels,
         file=file,
         content=content,
         filename=filename,

--- a/slack_primitive_cli/command/files.py
+++ b/slack_primitive_cli/command/files.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 @click.option("--thread_ts", help="Provide another message's ts value to upload this file as a reply.")
 @click.option("--title", help="Title of file.")
 @my_backoff
-def upload(token, channels, file, content, filename, filetype, initial_comment, thread_ts, title):  # noqa: ANN001, ANN201
+def upload(token, channel_id, file, content, filename, filetype, initial_comment, thread_ts, title):  # noqa: ANN001, ANN201
     set_logger()
     client = slack_sdk.WebClient(token=token)
 
@@ -30,7 +30,7 @@ def upload(token, channels, file, content, filename, filetype, initial_comment, 
         filename = os.path.basename(file)
 
     response = client.files_upload_v2(
-        channel=channels,
+        channel=channel_id,
         file=file,
         content=content,
         filename=filename,


### PR DESCRIPTION
`client.files_upload`は非推奨なので`files_upload_v2`を使うように変更しました。